### PR TITLE
Refactor string actions into object in IStorage

### DIFF
--- a/src/OhioBox.Storage.MySql.Tests/Mapping/UserDtoMap.cs
+++ b/src/OhioBox.Storage.MySql.Tests/Mapping/UserDtoMap.cs
@@ -1,4 +1,4 @@
-﻿using Moranbernate.Mapping;
+﻿using OhioBox.Moranbernate.Mapping;
 
 namespace OhioBox.Storage.MySql.Tests.Mapping
 {

--- a/src/OhioBox.Storage.MySql.Tests/OhioBox.Storage.MySql.Tests.csproj
+++ b/src/OhioBox.Storage.MySql.Tests/OhioBox.Storage.MySql.Tests.csproj
@@ -15,7 +15,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
 		<PackageReference Include="NUnitTestAdapter" Version="2.1.1" />
 		<PackageReference Include="nunit" Version="2.6.3" />
-		<PackageReference Include="OhioBox.Moranbernate" Version="2.0.5" />
+		<PackageReference Include="OhioBox.Moranbernate" Version="5.0.14" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\OhioBox.Storage.MySql\OhioBox.Storage.MySql.csproj" />

--- a/src/OhioBox.Storage.MySql/Moranbernate/AggregatedQueryRunner.cs
+++ b/src/OhioBox.Storage.MySql/Moranbernate/AggregatedQueryRunner.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Moranbernate.Querying;
+using OhioBox.Moranbernate.Querying;
 
 
 namespace OhioBox.Storage.MySql.Moranbernate

--- a/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateInitializer.cs
+++ b/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateInitializer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Reflection;
-using Moranbernate.Mapping;
+using OhioBox.Moranbernate.Mapping;
 
 namespace OhioBox.Storage.MySql.Moranbernate
 {

--- a/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateQueryBuilder.cs
+++ b/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateQueryBuilder.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using Moranbernate.Mapping;
-using Moranbernate.Querying;
-using Moranbernate.Querying.Restrictions;
-using Querying = Moranbernate.Querying;
+using OhioBox.Moranbernate.Mapping;
+using OhioBox.Moranbernate.Querying;
+using OhioBox.Moranbernate.Querying.Restrictions;
+using Querying = OhioBox.Moranbernate.Querying;
 
 namespace OhioBox.Storage.MySql.Moranbernate
 {
@@ -88,13 +88,13 @@ namespace OhioBox.Storage.MySql.Moranbernate
 			return this;
 		}
 
-		public IQueryBuilder<T> StartWith(Expression<Func<T, string>> member, string value)
+		public IQueryBuilder<T> StartWith(Expression<Func<T, object>> member, string value)
 		{
 			AddPredicate(w => w.StartWith(member, value));
 			return this;
 		}
 
-		public IQueryBuilder<T> Contains(Expression<Func<T, string>> member, string value)
+		public IQueryBuilder<T> Contains(Expression<Func<T, object>> member, string value)
 		{
 			AddPredicate(w => w.Contains(member, value));
 			return this;

--- a/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateStorage.cs
+++ b/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateStorage.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
-using Moranbernate.Querying;
-using Moranbernate.Utils;
+using OhioBox.Moranbernate.Querying;
+using OhioBox.Moranbernate.Utils;
 
 namespace OhioBox.Storage.MySql.Moranbernate
 {
@@ -126,7 +126,7 @@ namespace OhioBox.Storage.MySql.Moranbernate
 			return QueryInternal(q => q.Where(w => w.In(selector, ids)), "GetByField", () => " by field: " + ExpressionProcessor.FindMemberExpression(selector.Body) + " with " + ids.Count + " parameters");
 		}
 
-		private List<T> QueryInternal(Action<global::Moranbernate.Querying.IQueryBuilder<T>> action, string metricsKey, Func<string> logMessage)
+		private List<T> QueryInternal(Action<global::OhioBox.Moranbernate.Querying.IQueryBuilder<T>> action, string metricsKey, Func<string> logMessage)
 		{
 			var sw = Stopwatch.StartNew();
 			var rows = 0;

--- a/src/OhioBox.Storage.MySql/OhioBox.Storage.MySql.csproj
+++ b/src/OhioBox.Storage.MySql/OhioBox.Storage.MySql.csproj
@@ -27,10 +27,11 @@
 		<PackageReference Include="MySql.Data" Version="6.10.6" />
 		<PackageReference Include="OhioBox.Moranbernate" Version="5.0.14" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
+	<!--<ItemGroup Condition="'$(Configuration)' == 'Debug'">-->
+	<ItemGroup>
 		<ProjectReference Include="..\OhioBox.Storage\OhioBox.Storage.csproj" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(Configuration)' != 'Debug'">
+	<!--<ItemGroup Condition="'$(Configuration)' != 'Debug'">
 		<PackageReference Include="OhioBox.Storage" Version="2.0.7" />
-	</ItemGroup>
+	</ItemGroup>-->
 </Project>

--- a/src/OhioBox.Storage.MySql/OhioBox.Storage.MySql.csproj
+++ b/src/OhioBox.Storage.MySql/OhioBox.Storage.MySql.csproj
@@ -1,32 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net47;netstandard1.6</TargetFrameworks>
-    <PackageId>OhioBox.Storage.MySql</PackageId>
-    <BuildNumber>0</BuildNumber>
-    <PackageVersionSuffix>-dev</PackageVersionSuffix>
-    <AssemblyVersion>2.2.$(BuildNumber)</AssemblyVersion>
-    <FileVersion>$(AssemblyVersion)</FileVersion>
-    <PackageVersion>$(AssemblyVersion)$(PackageVersionSuffix)</PackageVersion>
-    <Authors>Sears Israel</Authors>
-    <Description>OhioBox.Storage integration with Moranbernate ORM</Description>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <RepositoryUrl></RepositoryUrl>
-    <Copyright>Copyright © 2017 SHC Israel. All rights reserved.</Copyright>
-    <PackageTags>ORM DB Database MySQL</PackageTags>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
-    <PackageReference Include="OhioBox.Storage" Version="2.0.7" />
-    <PackageReference Include="OhioBox.Moranbernate" Version="2.0.5" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
-    <PackageReference Include="OhioBox.Storage" Version="2.0.7" />
-    <PackageReference Include="OhioBox.Moranbernate" Version="2.0.5" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net47;netstandard1.6</TargetFrameworks>
+		<PackageId>OhioBox.Storage.MySql</PackageId>
+		<BuildNumber>0</BuildNumber>
+		<PackageVersionSuffix>-dev</PackageVersionSuffix>
+		<AssemblyVersion>2.2.$(BuildNumber)</AssemblyVersion>
+		<FileVersion>$(AssemblyVersion)</FileVersion>
+		<PackageVersion>$(AssemblyVersion)$(PackageVersionSuffix)</PackageVersion>
+		<Authors>Sears Israel</Authors>
+		<Description>OhioBox.Storage integration with Moranbernate ORM</Description>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<RepositoryUrl></RepositoryUrl>
+		<Copyright>Copyright © 2017 SHC Israel. All rights reserved.</Copyright>
+		<PackageTags>ORM DB Database MySQL CRUD</PackageTags>
+	</PropertyGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data" />
+		<PackageReference Include="MySql.Data" Version="6.10.6" />
+		<PackageReference Include="OhioBox.Moranbernate" Version="5.0.14" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+		<PackageReference Include="System.Collections" Version="4.3.0" />
+		<PackageReference Include="System.Runtime" Version="4.3.0" />
+		<PackageReference Include="MySql.Data" Version="6.10.6" />
+		<PackageReference Include="OhioBox.Moranbernate" Version="5.0.14" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
+		<ProjectReference Include="..\OhioBox.Storage\OhioBox.Storage.csproj" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(Configuration)' != 'Debug'">
+		<PackageReference Include="OhioBox.Storage" Version="2.0.7" />
+	</ItemGroup>
 </Project>

--- a/src/OhioBox.Storage/IQueryBuilder.cs
+++ b/src/OhioBox.Storage/IQueryBuilder.cs
@@ -38,9 +38,9 @@ namespace OhioBox.Storage
 
 		IQueryBuilder<T> Select(params Expression<Func<T, object>>[] fields);
 
-		IQueryBuilder<T> StartWith(Expression<Func<T, string>> member, string value);
+		IQueryBuilder<T> StartWith(Expression<Func<T, object>> member, string value);
 
-		IQueryBuilder<T> Contains(Expression<Func<T, string>> member, string value);
+		IQueryBuilder<T> Contains(Expression<Func<T, object>> member, string value);
 	}
 
 	public static class QueryBuilderExt


### PR DESCRIPTION
For IStorage to comply the recent MongoDB driver it needs to use object instead of string in string related action selectors