### PR TITLE
Add field exists operator to QueryBuilder

### DIFF
--- a/src/OhioBox.Storage.MySql.Tests/MoranbernateStorageTests.cs
+++ b/src/OhioBox.Storage.MySql.Tests/MoranbernateStorageTests.cs
@@ -124,6 +124,20 @@ namespace OhioBox.Storage.MySql.Tests
 		}
 
 		[Test]
+		public void Query_WhenQueryWithFieldDoesNotExist_ReturnRowsWithNullField()
+		{
+			AddUser(1L, "Shani");
+			AddUser(2L, "Doron", new DateTime(2018, 5, 31));
+			AddUser(3L, "Yuval");
+
+			var result = _target.Query(q => q.FieldDoesNotExist(x => x.UpdateDate));
+
+			Assert.That(result, Has.Count.EqualTo(2));
+			Assert.That(result, Has.Some.Matches<UserDto>(x => x.Id == 1L));
+			Assert.That(result, Has.Some.Matches<UserDto>(x => x.Id == 3L));
+		}
+
+		[Test]
 		public void UpdateByQuery_WhenCalled_UpdatesOnlyRelevantRows()
 		{
 			AddUser(1L, "Doron");

--- a/src/OhioBox.Storage.MySql.Tests/MoranbernateStorageTests.cs
+++ b/src/OhioBox.Storage.MySql.Tests/MoranbernateStorageTests.cs
@@ -111,6 +111,19 @@ namespace OhioBox.Storage.MySql.Tests
 		}
 
 		[Test]
+		public void Query_WhenQueryWithFieldExists_ReturnRowsWithNonNullField()
+		{
+			AddUser(1L, "Shani");
+			AddUser(2L, "Doron", new DateTime(2018, 5, 31));
+			AddUser(3L, "Yuval");
+
+			var result = _target.Query(q => q.FieldExists(x => x.UpdateDate));
+
+			Assert.That(result, Has.Count.EqualTo(1));
+			Assert.That(result, Has.Some.Matches<UserDto>(x => x.Id == 2L));
+		}
+
+		[Test]
 		public void UpdateByQuery_WhenCalled_UpdatesOnlyRelevantRows()
 		{
 			AddUser(1L, "Doron");

--- a/src/OhioBox.Storage.MySql.Tests/OhioBox.Storage.MySql.Tests.csproj
+++ b/src/OhioBox.Storage.MySql.Tests/OhioBox.Storage.MySql.Tests.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="OhioBox.Moranbernate" Version="5.1.16" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\OhioBox.Storage.MySql\OhioBox.Storage.MySql.csproj" />
+	  <ProjectReference Include="..\OhioBox.Storage.MySql\OhioBox.Storage.MySql.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateQueryBuilder.cs
+++ b/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateQueryBuilder.cs
@@ -112,6 +112,10 @@ namespace OhioBox.Storage.MySql.Moranbernate
 			return this;
 		}
 
+		public IQueryBuilder<T> FieldExists(Expression<Func<T, object>> member)
+		{
+			return IsNotNull(member);
+		}
 		public abstract IQueryBuilder<T> Take(int limit);
 
 		public abstract IQueryBuilder<T> Skip(int amount);

--- a/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateQueryBuilder.cs
+++ b/src/OhioBox.Storage.MySql/Moranbernate/MoranbernateQueryBuilder.cs
@@ -116,6 +116,13 @@ namespace OhioBox.Storage.MySql.Moranbernate
 		{
 			return IsNotNull(member);
 		}
+
+		public IQueryBuilder<T> FieldDoesNotExist(Expression<Func<T, object>> member)
+		{
+			return IsNull(member);
+		}
+
+
 		public abstract IQueryBuilder<T> Take(int limit);
 
 		public abstract IQueryBuilder<T> Skip(int amount);

--- a/src/OhioBox.Storage/IQueryBuilder.cs
+++ b/src/OhioBox.Storage/IQueryBuilder.cs
@@ -45,7 +45,10 @@ namespace OhioBox.Storage
 		IQueryBuilder<T> StartWith(Expression<Func<T, string>> member, string value);
 
 		IQueryBuilder<T> Contains(Expression<Func<T, string>> member, string value);
+
 		IQueryBuilder<T> FieldExists(Expression<Func<T, object>> member);
+
+		IQueryBuilder<T> FieldDoesNotExist(Expression<Func<T, object>> member);
 	}
 
 	public static class QueryBuilderExt

--- a/src/OhioBox.Storage/IQueryBuilder.cs
+++ b/src/OhioBox.Storage/IQueryBuilder.cs
@@ -45,6 +45,7 @@ namespace OhioBox.Storage
 		IQueryBuilder<T> StartWith(Expression<Func<T, string>> member, string value);
 
 		IQueryBuilder<T> Contains(Expression<Func<T, string>> member, string value);
+		IQueryBuilder<T> FieldExists(Expression<Func<T, object>> member);
 	}
 
 	public static class QueryBuilderExt


### PR DESCRIPTION
Add field exist operator in query builder to support document databases.
In MySql it is implemented as null check